### PR TITLE
Remove extra #main-outlet padding-top

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -52,10 +52,6 @@ tbody {
   color: $primary;
 }
 
-#main-outlet {
-  padding-top: 8em;
-}
-
 // Header
 .d-header {
   background-color: $secondary;


### PR DESCRIPTION
I couldn't quite tell why it was there, but the large `padding-top: 8em;` set for `#main-outlet` created a large gap between the top bar and the content. This is on a brand new instance without any other customizations.

## Before
![before](https://user-images.githubusercontent.com/516447/98450410-79f15b80-20f1-11eb-9108-5fbdb509dee7.png)

## After
![after](https://user-images.githubusercontent.com/516447/98450408-78c02e80-20f1-11eb-8e12-febc9c27c42a.png)