### PR TITLE
Remove opacity from alert banner

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -36,7 +36,7 @@ tbody {
 }
 
 .alert.alert-info {
-  background-color: $secondary-high#{50};
+  background-color: $secondary-very-high;
   border: 1px solid $love#{50};
   a {
     color: $quaternary;


### PR DESCRIPTION
Before:

<img width="1146" alt="Screenshot 2021-05-20 at 20 28 06" src="https://user-images.githubusercontent.com/11170663/119004728-7007b980-b9ac-11eb-9ed5-0f63f09ceb3d.png">

After:

<img width="1152" alt="Screenshot 2021-05-20 at 20 27 44" src="https://user-images.githubusercontent.com/11170663/119004424-30d96880-b9ac-11eb-8d10-5663d8eaf7a3.png">
